### PR TITLE
Fix charsetdetect build on Windows

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+
+updates:
+  # Maintain dependencies for GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,28 @@
+name: "CI"
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - "master"
+  pull_request:
+
+jobs:
+  build:
+    name: "Build / ${{ matrix.os}}"
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+
+    runs-on: "${{ matrix.os }}"
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          submodules: true
+
+      - name: Setup Haskell
+        uses: haskell-actions/setup@v2
+
+      - name: Build
+        run: cabal build

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Build artifacts
 dist/
+dist-newstyle/
 *.hi
 *.o
 

--- a/charsetdetect.cabal
+++ b/charsetdetect.cabal
@@ -74,14 +74,7 @@ Library
             cc-options: -fno-weak
             c-sources: cbits/dso_handle.c
 
-        -- This is a bit dodgy since g++ might link in more stuff, but will probably work in practice:
-        if os(windows)
-          if arch(x86_64)
-            extra-libraries:    stdc++-6 gcc_s_seh-1
-          else
-            extra-libraries:    stdc++-6 gcc_s_dw2-1
-        else
-          extra-libraries:      stdc++
+        extra-libraries: stdc++
 
         Include-Dirs:           libcharsetdetect
                                 libcharsetdetect/mozilla/extensions/universalchardet/src/base

--- a/charsetdetect.cabal
+++ b/charsetdetect.cabal
@@ -1,6 +1,6 @@
+Cabal-Version:       >= 1.8
 Name:                charsetdetect
 Version:             1.1.0.2
-Cabal-Version:       >= 1.6
 Category:            Text
 Synopsis:            Character set detection using Mozilla's Universal Character Set Detector
 Description:         Mozilla have developed a robust and efficient character set detection algorithm for


### PR DESCRIPTION
This PR makes the following changes:

- It fixes the build problems on Windows by [removing the Windows-specific extra-libraries stanza](https://github.com/batterseapower/charsetdetect/commit/8cfd1b019897ee06ef8604b3a656eb37836758f6).
- It [adds up Github Actions](https://github.com/batterseapower/charsetdetect/commit/ce5fcd642107e9dc438e2e3bd68777b531f60e4f) to verify that the Windows build succeeds.
- It [adds Dependabot](https://github.com/batterseapower/charsetdetect/commit/ec232296e403c3101d734a203b45d030459dc1cc) for easy maintenance of Github Actions.
- It [adds dist-newstyle to .gitignore](https://github.com/batterseapower/charsetdetect/commit/8e57afa3a5048a326053adb362f4f32b3ac7a9ec).
- It bumps the [Cabal-Version](https://github.com/batterseapower/charsetdetect/commit/145580823ab4f651f53edf63abef1a35d1e63153) to fixes a Cabal warning.